### PR TITLE
Initial attempt at GUI progress view using GLFW and opengl

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,9 @@ group 'cpw.mods.forge'
 sourceCompatibility = 1.8
 targetCompatibility = 1.8
 
+project.ext.lwjglVersion = "3.2.1"
+project.ext.jomlVersion = "1.9.17"
+
 repositories {
     mavenCentral()
     maven {
@@ -86,6 +89,13 @@ dependencies {
     implementation("cpw.mods:modlauncher:3.2.+")
     implementation("com.google.code.gson:gson:2.8.0")
     implementation("org.apache.logging.log4j:log4j-api:2.11.2")
+
+    // lwjgl and glfw for progress window, provided by Minecraft client
+    compileOnly("org.lwjgl:lwjgl:$lwjglVersion")
+    compileOnly("org.lwjgl:lwjgl-glfw:$lwjglVersion")
+    compileOnly("org.lwjgl:lwjgl-opengl:$lwjglVersion")
+    compileOnly("org.lwjgl:lwjgl-stb:$lwjglVersion")
+    compileOnly("org.joml:joml:${jomlVersion}")
 }
 
 task zip(type: Zip, dependsOn: jar) {

--- a/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
@@ -41,7 +41,7 @@ public class CurseLocator implements IModLocator {
         // This will work well enough for displaying progress GUI
         try {
             Class.forName("org.lwjgl.glfw.GLFW");
-            return Dist.DEDICATED_SERVER;
+            return Dist.CLIENT;
         } catch (ClassNotFoundException ignored) {
             return Dist.DEDICATED_SERVER;
         }

--- a/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
@@ -2,12 +2,12 @@ package cpw.mods.forge.cursepacklocator;
 
 import cpw.mods.modlauncher.Launcher;
 import cpw.mods.modlauncher.api.IEnvironment;
+import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.forgespi.Environment;
 import net.minecraftforge.forgespi.locating.IModFile;
 import net.minecraftforge.forgespi.locating.IModLocator;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
@@ -28,12 +28,23 @@ public class CurseLocator implements IModLocator {
                 .getProperty(IEnvironment.Keys.GAMEDIR.get())
                 .orElseThrow(()->new IllegalStateException("MISSING GAMEDIR?!"));
         fileCacheManager = new FileCacheManager();
-        pack = new CursePack(gameDir, fileCacheManager, new ProgressOutput());
+        pack = new CursePack(gameDir, fileCacheManager, getDist().isClient() ? new ClientProgressOutput() : new ServerProgressOutput());
     }
 
     public CurseLocator(Path dir) throws IOException {
         fileCacheManager = new FileCacheManager(DirHandler.createOrGetDirectory(dir, "dummycache"));
-        pack = new CursePack(dir, fileCacheManager, new ProgressOutput());
+        pack = new CursePack(dir, fileCacheManager, getDist().isClient() ? new ClientProgressOutput() : new ServerProgressOutput());
+    }
+
+    private static Dist getDist() {
+        // How to detect dist properly from here?
+        // This will work well enough for displaying progress GUI
+        try {
+            Class.forName("org.lwjgl.glfw.GLFW");
+            return Dist.DEDICATED_SERVER;
+        } catch (ClassNotFoundException ignored) {
+            return Dist.DEDICATED_SERVER;
+        }
     }
 
     @Override

--- a/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/CurseLocator.java
@@ -28,12 +28,12 @@ public class CurseLocator implements IModLocator {
                 .getProperty(IEnvironment.Keys.GAMEDIR.get())
                 .orElseThrow(()->new IllegalStateException("MISSING GAMEDIR?!"));
         fileCacheManager = new FileCacheManager();
-        pack = new CursePack(gameDir, fileCacheManager);
+        pack = new CursePack(gameDir, fileCacheManager, new ProgressOutput());
     }
 
     public CurseLocator(Path dir) throws IOException {
         fileCacheManager = new FileCacheManager(DirHandler.createOrGetDirectory(dir, "dummycache"));
-        pack = new CursePack(dir, fileCacheManager);
+        pack = new CursePack(dir, fileCacheManager, new ProgressOutput());
     }
 
     @Override

--- a/src/main/java/cpw/mods/forge/cursepacklocator/CursePack.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/CursePack.java
@@ -30,9 +30,9 @@ public class CursePack {
     private List<String> fileNames = new ArrayList<>();
     private Set<String> excludedProjectIds = new HashSet<>();
     private Set<String> excludedFileIds = new HashSet<>();
-    private ProgressOutput progress;
+    private IProgressOutput progress;
 
-    public CursePack(final Path gameDir, final FileCacheManager fileCacheManager, ProgressOutput progress) {
+    public CursePack(final Path gameDir, final FileCacheManager fileCacheManager, IProgressOutput progress) {
         this.fileCacheManager = fileCacheManager;
         this.progress = progress;
         JsonObject manifest1 = null;
@@ -130,7 +130,7 @@ public class CursePack {
 
     public void waitForPackDownload() {
         try {
-            progress.progressDisplayLoop();
+            progress.displayAndWait();
             packDownload.get();
         } catch (InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);

--- a/src/main/java/cpw/mods/forge/cursepacklocator/IProgressOutput.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/IProgressOutput.java
@@ -1,0 +1,14 @@
+package cpw.mods.forge.cursepacklocator;
+
+public interface IProgressOutput {
+
+    void displayAndWait();
+
+    void finish();
+
+    void setFileCount(int size);
+
+    void beginFile(String projectID, String fileID, String fileName);
+
+    void endFile(String projectID, String fileID);
+}

--- a/src/main/java/cpw/mods/forge/cursepacklocator/PackFile.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/PackFile.java
@@ -21,7 +21,7 @@ public class PackFile {
         this.fileId = fileId;
     }
 
-    public void loadFileIntoPlace(final Path targetPackDir, final FileCacheManager fileCacheManager, final ProgressOutput progress) {
+    public void loadFileIntoPlace(final Path targetPackDir, final FileCacheManager fileCacheManager, final IProgressOutput progress) {
         LOGGER.info("CursePackDownloader is loading file {} - {}", this.projectId, this.fileId);
         final Path path = fileCacheManager.downloadFile(this.projectId, this.fileId);
         final JsonObject info = fileCacheManager.downloadInfo(this.projectId, this.fileId);

--- a/src/main/java/cpw/mods/forge/cursepacklocator/ProgressOutput.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/ProgressOutput.java
@@ -1,0 +1,201 @@
+package cpw.mods.forge.cursepacklocator;
+
+import static org.lwjgl.glfw.Callbacks.glfwFreeCallbacks;
+import static org.lwjgl.glfw.GLFW.GLFW_FALSE;
+import static org.lwjgl.glfw.GLFW.GLFW_OPENGL_DEBUG_CONTEXT;
+import static org.lwjgl.glfw.GLFW.GLFW_RESIZABLE;
+import static org.lwjgl.glfw.GLFW.GLFW_TRUE;
+import static org.lwjgl.glfw.GLFW.GLFW_VISIBLE;
+import static org.lwjgl.glfw.GLFW.glfwCreateWindow;
+import static org.lwjgl.glfw.GLFW.glfwDefaultWindowHints;
+import static org.lwjgl.glfw.GLFW.glfwDestroyWindow;
+import static org.lwjgl.glfw.GLFW.glfwGetPrimaryMonitor;
+import static org.lwjgl.glfw.GLFW.glfwGetVideoMode;
+import static org.lwjgl.glfw.GLFW.glfwGetWindowSize;
+import static org.lwjgl.glfw.GLFW.glfwInit;
+import static org.lwjgl.glfw.GLFW.glfwMakeContextCurrent;
+import static org.lwjgl.glfw.GLFW.glfwPollEvents;
+import static org.lwjgl.glfw.GLFW.glfwSetErrorCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetKeyCallback;
+import static org.lwjgl.glfw.GLFW.glfwSetWindowPos;
+import static org.lwjgl.glfw.GLFW.glfwShowWindow;
+import static org.lwjgl.glfw.GLFW.glfwSwapBuffers;
+import static org.lwjgl.glfw.GLFW.glfwSwapInterval;
+import static org.lwjgl.glfw.GLFW.glfwTerminate;
+import static org.lwjgl.glfw.GLFW.glfwWindowHint;
+import static org.lwjgl.glfw.GLFW.glfwWindowShouldClose;
+import static org.lwjgl.opengl.GL11.GL_BLEND;
+import static org.lwjgl.opengl.GL11.GL_COLOR_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_DEPTH_BUFFER_BIT;
+import static org.lwjgl.opengl.GL11.GL_MODELVIEW;
+import static org.lwjgl.opengl.GL11.GL_PROJECTION;
+import static org.lwjgl.opengl.GL11.GL_QUADS;
+import static org.lwjgl.opengl.GL11.glBegin;
+import static org.lwjgl.opengl.GL11.glClear;
+import static org.lwjgl.opengl.GL11.glClearColor;
+import static org.lwjgl.opengl.GL11.glColor3f;
+import static org.lwjgl.opengl.GL11.glDrawArrays;
+import static org.lwjgl.opengl.GL11.glEnable;
+import static org.lwjgl.opengl.GL11.glEnableClientState;
+import static org.lwjgl.opengl.GL11.glEnd;
+import static org.lwjgl.opengl.GL11.glLoadIdentity;
+import static org.lwjgl.opengl.GL11.glMatrixMode;
+import static org.lwjgl.opengl.GL11.glOrtho;
+import static org.lwjgl.opengl.GL11.glPopMatrix;
+import static org.lwjgl.opengl.GL11.glPushMatrix;
+import static org.lwjgl.opengl.GL11.glScalef;
+import static org.lwjgl.opengl.GL11.glTranslatef;
+import static org.lwjgl.opengl.GL11.glVertex2f;
+import static org.lwjgl.opengl.GL11.glVertexPointer;
+import static org.lwjgl.system.MemoryStack.stackPush;
+import static org.lwjgl.system.MemoryUtil.NULL;
+
+import org.lwjgl.glfw.GLFWErrorCallback;
+import org.lwjgl.glfw.GLFWVidMode;
+import org.lwjgl.opengl.GL;
+import org.lwjgl.opengl.GL11;
+import org.lwjgl.opengl.GLUtil;
+import org.lwjgl.stb.STBEasyFont;
+import org.lwjgl.system.Callback;
+import org.lwjgl.system.MemoryStack;
+import org.lwjgl.system.MemoryUtil;
+
+import java.nio.ByteBuffer;
+import java.nio.IntBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class ProgressOutput {
+
+    //private final Dist dist;
+    private int totalFiles;
+    private final AtomicInteger downloadedCount = new AtomicInteger(0);
+    private volatile boolean isRunning = false;
+
+    private final int screenWidth = 550;
+    private final int screenHeight = 60;
+
+    ProgressOutput(/*Dist dist*/) {
+        // this.dist = dist; // I can't figure out how to access dist here
+    }
+
+    void progressDisplayLoop() {
+        //if (!dist.isClient()) {
+        //    return;
+        //}
+        try {
+            glfwDrawLoop();
+        } catch (Throwable t) {
+            // ignore, this probably means we are dedicated server. TODO: This needs to be changed
+        }
+    }
+
+    private void glfwDrawLoop() {
+        isRunning = true;
+        GLFWErrorCallback.createPrint(System.err).set();
+
+        if (!glfwInit()) {
+            throw new IllegalStateException("Unable to initialize GLFW");
+        }
+
+        glfwDefaultWindowHints();
+        glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
+        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
+
+
+        long window = glfwCreateWindow(screenWidth, screenHeight, "CursePackLocator mod download progress", NULL, NULL);
+        if (window == NULL) {
+            throw new RuntimeException("Failed to create the GLFW window"); // ignore it and make the GUI optional?
+        }
+
+        glfwSetKeyCallback(window, (windowHandle, key, scancode, action, mods) -> {
+            // handle quitting here?
+        });
+
+        try (MemoryStack stack = stackPush()) {
+            IntBuffer pWidth = stack.mallocInt(1);
+            IntBuffer pHeight = stack.mallocInt(1);
+            glfwGetWindowSize(window, pWidth, pHeight);
+            GLFWVidMode vidmode = glfwGetVideoMode(glfwGetPrimaryMonitor());
+            // Center the window
+            glfwSetWindowPos(
+                    window,
+                    (vidmode.width() - pWidth.get(0)) / 2,
+                    (vidmode.height() - pHeight.get(0)) / 2
+            );
+        }
+        glfwMakeContextCurrent(window);
+        glfwSwapInterval(1);
+        glfwShowWindow(window);
+        GL.createCapabilities();
+        glClearColor(0.1f, 0.1f, 0.3f, 0.0f);
+        Callback debugProc = GLUtil.setupDebugMessageCallback(); // may return null if the debug mode is not available
+
+
+        while (isRunning && !glfwWindowShouldClose(window)) {
+            glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+            drawProgress(downloadedCount.get() / (float) totalFiles);
+            glfwSwapBuffers(window);
+            glfwPollEvents();
+        }
+        // cleanup
+        if ( debugProc != null )
+            debugProc.free();
+        glfwFreeCallbacks(window);
+        glfwDestroyWindow(window);
+        glfwTerminate();
+        glfwSetErrorCallback(null).free();
+
+    }
+
+    private void drawProgress(final float progress) {
+        glMatrixMode(GL_PROJECTION);
+        glLoadIdentity();
+        glOrtho(0.0D, screenWidth, screenHeight, 0.0D, -1000.0D, 1000.0D);
+        glMatrixMode(GL_MODELVIEW);
+        glLoadIdentity();
+
+        // replace with more modern opengl?
+        glBegin(GL_QUADS);
+        glColor3f(0.1f, 0.1f, 0.9f);
+        glVertex2f(0, 0);
+        glVertex2f(0, screenHeight);
+        glVertex2f(screenWidth * progress, screenHeight);
+        glVertex2f(screenWidth * progress, 0);
+        glEnd();
+
+        glEnableClientState(GL11.GL_VERTEX_ARRAY);
+        glEnable(GL_BLEND);
+
+        String message = String.format("Downloading curse mod pack: %.1f%%", progress * 100);
+        ByteBuffer charBuffer = MemoryUtil.memAlloc(message.length() * 270);
+        int quads = STBEasyFont.stb_easy_font_print(0, 0, message, null, charBuffer);
+
+        glVertexPointer(3, GL11.GL_FLOAT, 16, charBuffer);
+        glPushMatrix();
+        glTranslatef(1, screenHeight / 2f - STBEasyFont.stb_easy_font_height(message) / 2f, 0);
+        glScalef(2, 2, 1);
+        glColor3f(0, 0, 0);
+        glDrawArrays(GL11.GL_QUADS, 0, quads * 4);
+        glPopMatrix();
+        MemoryUtil.memFree(charBuffer);
+        //System.exit(-1);
+    }
+
+    void finish() {
+        isRunning = false;
+    }
+
+    void setFileCount(final int size) {
+        totalFiles = size;
+    }
+
+    // these 2 methods can be used to display the mods currently being downloaded. It may not be very useful without a file name.
+
+    void beginFile(final String projectID, final String fileID, final String fileName) {
+    }
+
+    void endFile(final String projectID, final String fileID) {
+        downloadedCount.incrementAndGet();
+    }
+}

--- a/src/main/java/cpw/mods/forge/cursepacklocator/ProgressOutput.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/ProgressOutput.java
@@ -100,8 +100,6 @@ class ProgressOutput {
         glfwDefaultWindowHints();
         glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
         glfwWindowHint(GLFW_RESIZABLE, GLFW_FALSE);
-        glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GLFW_TRUE);
-
 
         long window = glfwCreateWindow(screenWidth, screenHeight, "CursePackLocator mod download progress", NULL, NULL);
         if (window == NULL) {
@@ -129,8 +127,6 @@ class ProgressOutput {
         glfwShowWindow(window);
         GL.createCapabilities();
         glClearColor(0.1f, 0.1f, 0.3f, 0.0f);
-        Callback debugProc = GLUtil.setupDebugMessageCallback(); // may return null if the debug mode is not available
-
 
         while (isRunning && !glfwWindowShouldClose(window)) {
             glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -138,9 +134,6 @@ class ProgressOutput {
             glfwSwapBuffers(window);
             glfwPollEvents();
         }
-        // cleanup
-        if ( debugProc != null )
-            debugProc.free();
         glfwFreeCallbacks(window);
         glfwDestroyWindow(window);
         glfwTerminate();

--- a/src/main/java/cpw/mods/forge/cursepacklocator/ServerProgressOutput.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/ServerProgressOutput.java
@@ -1,0 +1,21 @@
+package cpw.mods.forge.cursepacklocator;
+
+public class ServerProgressOutput implements IProgressOutput {
+
+    // server has logging that is expected to be visible, so either no-op or display swing GUI if not headless
+
+    @Override public void displayAndWait() {
+    }
+
+    @Override public void finish() {
+    }
+
+    @Override public void setFileCount(int size) {
+    }
+
+    @Override public void beginFile(String projectID, String fileID, String fileName) {
+    }
+
+    @Override public void endFile(String projectID, String fileID) {
+    }
+}


### PR DESCRIPTION
Works, but not tested on server or platforms other than linux.

This shows how it can be done, but there are definitely some improvements to be done. I wasn't able to find a way to check which side I'm on (probably missing something obvious) so I did a hacky try...catch to check if GLFW class exists. Server implementation is currently a no-op, but it can be changed to include a swing-based progress window for non-headless server.

The progress view is currently very simple, as I wasn't sure what it should actually look like. It currently only shows progress bar (that fills the whole window) and progress percentage. Should be easy to modify to show which files are currently being downloaded.

Here is what it looks like

![image](https://user-images.githubusercontent.com/1349112/65823535-5c985f80-e258-11e9-9ee2-14a18c48d312.png)

