### PR TITLE
Fix Murmur2 hash implementation

### DIFF
--- a/src/main/java/cpw/mods/forge/cursepacklocator/Murmur2.java
+++ b/src/main/java/cpw/mods/forge/cursepacklocator/Murmur2.java
@@ -73,13 +73,13 @@ public class Murmur2 {
         int left = length - len_m;
         if (left != 0) {
             if (left >= 3) {
-                h ^= (int) data[length - 3] << 16;
+                h ^= (int) data[length - (left - 2)] << 16;
             }
             if (left >= 2) {
-                h ^= (int) data[length - 2] << 8;
+                h ^= (int) data[length - (left - 1)] << 8;
             }
             if (left >= 1) {
-                h ^= (int) data[length - 1];
+                h ^= (int) data[length - left];
             }
 
             h *= M_32;


### PR DESCRIPTION
I found that the Murmur2 hash implementation you are using is incorrect - it mixes the last 3 bytes in the wrong order, resulting in incorrect hashes for *some* files (most files will still be correct). See https://github.com/prasanthj/hasher/pull/3 for more information.